### PR TITLE
fix cicd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           url: ${{ secrets.KUBOARD_API_URL }}/resource/updateImageTag
           method: 'PUT'
           customHeaders: '{"Content-Type": "application/json", "Cookie": "KuboardUsername=${{ secrets.KUBOARD_USERNAME }}; KuboardAccessKey=${{ secrets.KUBOARD_ACCESS_KEY }}"}'
-          data: '{"kind":"deployments","namespace":"${{ inputs.k8s-namespace }}","name":"${{ inputs.k8s-workload }}","images":{"${{ inputs.image-name }}":"${{ inputs.image-name }}:${{ inputs.image-tag }}"}}'
+          data: '{"kind":"deployments","namespace":"${{ inputs.k8s-namespace }}","name":"${{ inputs.k8s-workload }}","images":{"ghcr.io/magickbase/gwscan-api":"ghcr.io/magickbase/gwscan-api:${{ inputs.image-tag }}"}}'
       - name: Restart container
         uses: fjogeleit/http-request-action@v1
         with:


### PR DESCRIPTION
Because the `magickbase` in the image-name string conflicts with the secret, the value of image-name cannot be obtained in the deploy stage. It is fixed directly without passing this variable value in the build step.